### PR TITLE
Enabled cors, update readme

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -9,3 +9,29 @@ pyspice-post-installation --install-ngspice-dll
 
 ## Note
 Be in directory without any whitespace, recommended just to put it in your C drive
+
+backend runs on http://127.0.0.1:8000
+
+# Backend End Points 
+## Auth
+- /auth/login 
+  takes string username and string password
+  returns { "access_token" : {token here}, "token_type" : "bearer" }
+- /auth/register
+  takes 
+  {
+    "username": "string",
+    "password": "string",
+    "email": "string",
+    "full_name": "string"
+  }
+
+  returns { "msg": "User created successfully" }
+- /auth/me -- for testing token
+  takes nothing, just put token in the header
+  returns {
+    "username": "string",
+    "hashed_password": "string",
+    "email": "string",
+    "full_name": "string"
+  }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends
 from fastapi.security import OAuth2PasswordBearer
+from fastapi.middleware.cors import CORSMiddleware  
 from pymongo.mongo_client import MongoClient
 from pymongo.server_api import ServerApi
 from config.db import users_collection, simulations_collection, client
@@ -13,15 +14,27 @@ try:
 except Exception as e:
     print(e)
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+## CORS Settings
+origins = [
+    "http://localhost",
+    "http://localhost:5173",
+    "https://femspice.noxunya.dev"
+]
+
+
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
 app.include_router(auth.router)
 app.include_router(simulate.router)
 
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
-
-# @app.get("/items/")
-# async def read_items(token: Annotated[str, Depends(oauth2_scheme)]):
-#     return {"token": token}


### PR DESCRIPTION
This pull request adds documentation for backend API endpoints and configures CORS support in the FastAPI backend to enable frontend integration. The most important changes are grouped below:

**Documentation Improvements:**

* Expanded the `backend/README.md` to document backend API endpoints, including authentication endpoints (`/auth/login`, `/auth/register`, `/auth/me`), their required parameters, and example responses. Also clarified the backend's default running address.

**Backend Configuration:**

* Added and configured `CORSMiddleware` in `main.py` to allow cross-origin requests from local development and production frontend domains, supporting frontend-backend communication. [[1]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903R3) [[2]](diffhunk://#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903L16-L27)
* Removed the root endpoint (`/`) and unused example code from `main.py` to clean up the API surface.